### PR TITLE
Add rsmi_version_get_function()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,37 +28,54 @@
 #
 cmake_minimum_required(VERSION 3.5.0)
 
-set(ROCM_SMI "rocm_smi")
-set(ROCM_SMI_COMPONENT "lib${ROCM_SMI}")
-set(ROCM_SMI_TARGET "${ROCM_SMI}64")
-
-project(${ROCM_SMI_TARGET})
-
 ## Set default module path if not already set
 if(NOT DEFINED CMAKE_MODULE_PATH)
     set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
 endif()
-
 ## Include common cmake modules
 include(utils)
 
-## Setup the package version.
-get_version ("1.0.0")
+set(ROCM_SMI "rocm_smi")
+set(ROCM_SMI_COMPONENT "lib${ROCM_SMI}")
+set(ROCM_SMI_TARGET "${ROCM_SMI}64")
+
+# The following default version values should be updated as appropriate for
+# ABI breaks (update MAJOR and MINOR), and ABI/API additions (update MINOR).
+# Until ABI stabilizes VERSION_MAJOR will be 0. This should be over-ridden
+# by git tags (through "git describe") when they are present.
+set(ROCM_SMI_LIB_VERSION_MAJOR 0)
+set(ROCM_SMI_LIB_VERSION_MINOR 1)
+
+################# Determine the library version #########################
+## Setup the package version based on git tags.
+set(LIB_SO_VERSION_STR
+              "${ROCM_SMI_LIB_VERSION_MAJOR}.${ROCM_SMI_LIB_VERSION_MINOR}.0")
+get_version(${LIB_SO_VERSION_STR} "rsmi")
+
+# VERSION_* variables should be set by get_version
+set(LIB_SO_VERSION_STR ${VERSION_STRING})
+set(${ROCM_SMI}_VERSION_MAJOR "${VERSION_MAJOR}")
+set(${ROCM_SMI}_VERSION_MINOR "${VERSION_MINOR}")
+set(${ROCM_SMI}_VERSION_PATCH "${VERSION_PATCH}")
+set(${ROCM_SMI}_VERSION_BUILD "${VERSION_BUILD}")
+
+# Debian package specific variables
+# Set a default value for the package version
+set(VERSION_STRING "1.0.0")
+get_version(${VERSION_STRING} "roc")
+
+# VERSION_* variables should be set by get_version
+set(BUILD_VERSION_STRING "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}")
+
+project(${ROCM_SMI_TARGET})
+
+# Create a configure file to get version info from within library
+configure_file(
+  "${PROJECT_SOURCE_DIR}/src/${ROCM_SMI_TARGET}Config.in"
+  "${PROJECT_SOURCE_DIR}/include/rocm_smi/${ROCM_SMI_TARGET}Config.h")
 
 if (NOT DEFINED CPACK_PACKAGE_VENDOR)
     set(CPACK_PACKAGE_VENDOR "AMD")
-endif()
-
-if (NOT DEFINED CPACK_PACKAGE_VERSION_MAJOR)
-    set(CPACK_PACKAGE_VERSION_MAJOR "1")
-endif()
-
-if (NOT DEFINED CPACK_PACKAGE_VERSION_MINOR)
-    set(CPACK_PACKAGE_VERSION_MINOR "0")
-endif()
-
-if (NOT DEFINED CPACK_PACKAGE_VERSION_PATCH)
-    set(CPACK_PACKAGE_VERSION_PATCH "0")
 endif()
 
 if (NOT DEFINED CPACK_PACKAGE_CONTACT)
@@ -70,14 +87,7 @@ set(CPACK_PACKAGE_DESCRIPTION_SUMMARY
                  "ROCm System Management Interface library")
 endif()
 
-set(LIB_VERSION_STRING
-        "${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}")
-# Debian package specific variables
-
-set(BUILD_VERSION_STRING
-        "${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_PATCH}")
-
-set(CPACK_PACKAGE_FILE_NAME "rocm_smi_lib64-${LIB_VERSION_STRING}")
+set(CPACK_PACKAGE_FILE_NAME "rocm_smi_lib64-${BUILD_VERSION_STRING}")
 ## Verbose output.
 set(CMAKE_VERBOSE_MAKEFILE on)
 
@@ -112,10 +122,6 @@ set(SMI_INC_LIST ${SMI_INC_LIST} "${INC_DIR}/rocm_smi_utils.h")
 set(SMI_INC_LIST ${SMI_INC_LIST} "${INC_DIR}/rocm_smi_common.h")
 set(SMI_INC_LIST ${SMI_INC_LIST} "${INC_DIR}/rocm_smi_exception.h")
 
-
-# rocm_smi_device.h 
-#      rocm_smi.h rocm_smi_main.h rocm_smi_monitor.h")
-
 set(SMI_EXAMPLE_EXE "rocm_smi_ex")
 
 add_executable(${SMI_EXAMPLE_EXE} "example/rocm_smi_example.cc")
@@ -123,10 +129,10 @@ target_link_libraries(${SMI_EXAMPLE_EXE} ${ROCM_SMI_TARGET})
 add_library(${ROCM_SMI_TARGET} SHARED ${SMI_SRC_LIST} ${SMI_INC_LIST})
 
 ## Set the VERSION and SOVERSION values
-set_property(TARGET ${ROCM_SMI_TARGET} PROPERTY VERSION "${LIB_VERSION_STRING}")
 set_property(TARGET ${ROCM_SMI_TARGET}
-             PROPERTY SOVERSION "${CPACK_PACKAGE_VERSION_MAJOR}")
-
+                             PROPERTY VERSION "${LIB_SO_VERSION_STR}")
+set_property(TARGET ${ROCM_SMI_TARGET}
+             PROPERTY SOVERSION "${ROCM_SMI_LIB_VERSION_MAJOR}")
 
 ## If the library is a release, strip the target library
 if ("${CMAKE_BUILD_TYPE}" STREQUAL Release)
@@ -148,7 +154,8 @@ set(CPACK_GENERATOR "DEB;RPM"  CACHE STRING "Default packaging generators.")
 ## Add the install directives for the runtime library.
 install(TARGETS ${ROCM_SMI_TARGET}
           LIBRARY DESTINATION ${ROCM_SMI}/lib COMPONENT ${ROCM_SMI_COMPONENT})
-install(FILES ${SOURCE_DIR}/include/rocm_smi/rocm_smi.h DESTINATION rocm_smi/include/rocm_smi)
+install(FILES ${SOURCE_DIR}/include/rocm_smi/rocm_smi.h
+                                        DESTINATION rocm_smi/include/rocm_smi)
 
 ## Add the packaging directives for the runtime library.
 
@@ -176,5 +183,4 @@ if (DOXYGEN_FOUND)
 else()
   message("Doxygen is not found. Will not generate documents.")
 endif(DOXYGEN_FOUND)
-
 

--- a/cmake_modules/utils.cmake
+++ b/cmake_modules/utils.cmake
@@ -85,15 +85,14 @@ endfunction ()
 ## using versioning tags and git describe.
 ## Passes back a packaging version string
 ## and a library version string.
-function ( get_version DEFAULT_VERSION_STRING )
+function(get_version DEFAULT_VERSION_STRING VERSION_PREFIX)
 
     parse_version ( ${DEFAULT_VERSION_STRING} )
 
     find_program ( GIT NAMES git )
 
     if ( GIT )
-
-        execute_process ( COMMAND git describe --dirty --long --match [0-9]*
+        execute_process ( COMMAND git describe --dirty --long --match ${VERSION_PREFIX}-[0-9.]*
                           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                           OUTPUT_VARIABLE GIT_TAG_STRING
                           OUTPUT_STRIP_TRAILING_WHITESPACE

--- a/include/rocm_smi/rocm_smi.h
+++ b/include/rocm_smi/rocm_smi.h
@@ -312,18 +312,18 @@ rsmi_dev_pci_bandwidth_get(uint32_t dv_ind, rsmi_pcie_bandwidth *bandwidth);
 
 /**
  *  @brief Control the set of allowed PCIe bandwidths that can be used.
- *  
+ *
  *  @details Given a device index @p dv_ind and a 64 bit bitmask @p bw_bitmask,
  *  this function will limit the set of allowable bandwidths. If a bit in @p
  *  bw_bitmask has a value of 1, then the frequency (as ordered in an
  *  rsmi_frequencies returned by rsmi_dev_get_gpu_clk_freq()) corresponding
  *  to that bit index will be allowed.
- *  
+ *
  *  This function will change the performance level to
  *  ::RSMI_DEV_PERF_LEVEL_MANUAL in order to modify the set of allowable
  *  band_widths. Caller will need to set to ::RSMI_DEV_PERF_LEVEL_AUTO in order
  *  to get back to default state.
- *  
+ *
  *  All bits with indices greater than or equal to
  *  rsmi_pcie_bandwidth.transfer_rate.num_supported will be ignored.
  *
@@ -630,7 +630,7 @@ rsmi_status_t rsmi_dev_fan_speed_get(uint32_t dv_ind,
  *  @brief Get the max. fan speed of the device with provided device index.
  *
  *  @details Given a device index @p dv_ind and a pointer to a uint32_t
- *  @p max_speed, this function will write the maxirsmi_dev_power_profile_semum fan speed possible to
+ *  @p max_speed, this function will write the maximum fan speed possible to
  *  the uint32_t pointed to by @p max_speed
  *
  *  @param[in] dv_ind a device index

--- a/include/rocm_smi/rocm_smi.h
+++ b/include/rocm_smi/rocm_smi.h
@@ -256,6 +256,15 @@ typedef struct {
     uint32_t lanes[RSMI_MAX_NUM_FREQUENCIES];
 } rsmi_pcie_bandwidth;
 
+/**
+ * @brief This structure holds version information.
+ */
+typedef struct {
+    uint32_t major;     //!< Major version
+    uint32_t minor;     //!< Minor version
+    uint32_t patch;     //!< Patch, build  or stepping version
+    const char *build;  //!< Build string
+} rsmi_version;
 
 /**
  *  @brief Initialize Rocm SMI.
@@ -266,7 +275,7 @@ typedef struct {
  *  @param[in] init_flags Bit flags that tell SMI how to initialze. Not
  *  currently used.
  *
- *  @retval RSMI_STATUS_SUCCESS is returned upon successful call.
+ *  @retval ::RSMI_STATUS_SUCCESS is returned upon successful call.
  */
 rsmi_status_t rsmi_init(uint64_t init_flags);
 
@@ -287,7 +296,7 @@ rsmi_status_t rsmi_shut_down(void);
  *  successful call, the value num_devices will contain the number of monitor
  *  devices.
  *
- *  @retval RSMI_STATUS_SUCCESS is returned upon successful call.
+ *  @retval ::RSMI_STATUS_SUCCESS is returned upon successful call.
  */
 rsmi_status_t rsmi_num_monitor_devices(uint32_t *num_devices);
 
@@ -304,11 +313,30 @@ rsmi_status_t rsmi_num_monitor_devices(uint32_t *num_devices);
  *  @param[inout] bandwidth a pointer to a caller provided rsmi_pcie_bandwidth
  *  structure to which the frequency information will be written
  *
- *  @retval RSMI_STATUS_SUCCESS is returned upon successful call.
+ *  @retval ::RSMI_STATUS_SUCCESS is returned upon successful call.
  *
  */
 rsmi_status_t
 rsmi_dev_pci_bandwidth_get(uint32_t dv_ind, rsmi_pcie_bandwidth *bandwidth);
+
+/**
+ * @brief Get percentage of time device is busy doing any processing
+ *
+ * @details Given a device index @p dv_ind, this function returns the
+ * percentage of time that the specified device is busy. The device is
+ * considered busy if any one or more of its sub-blocks are working, and idle
+ * if none of the sub-blocks are working.
+ *
+ * @param[in] dv_ind a device index
+ *
+ * @param[inout] busy_percent a pointer to the uint32_t to which the busy
+ * percent will be written
+ *
+ * @retval ::RSMI_STATUS_SUCCESS is returned upon successful call
+ *
+ */
+rsmi_status_t
+rsmi_dev_busy_percent_get(uint32_t dv_ind, uint32_t *busy_percent);
 
 /**
  *  @brief Control the set of allowed PCIe bandwidths that can be used.
@@ -316,7 +344,7 @@ rsmi_dev_pci_bandwidth_get(uint32_t dv_ind, rsmi_pcie_bandwidth *bandwidth);
  *  @details Given a device index @p dv_ind and a 64 bit bitmask @p bw_bitmask,
  *  this function will limit the set of allowable bandwidths. If a bit in @p
  *  bw_bitmask has a value of 1, then the frequency (as ordered in an
- *  rsmi_frequencies returned by rsmi_dev_get_gpu_clk_freq()) corresponding
+ *  ::rsmi_frequencies returned by rsmi_dev_get_gpu_clk_freq()) corresponding
  *  to that bit index will be allowed.
  *
  *  This function will change the performance level to
@@ -349,7 +377,7 @@ rsmi_status_t rsmi_dev_pci_bandwidth_set(uint32_t dv_ind, uint64_t bw_bitmask);
  *  @param[inout] bdfid a pointer to uint64_t to which the device bdfid value
  *  will be written
  *
- *  @retval RSMI_STATUS_SUCCESS is returned upon successful call.
+ *  @retval ::RSMI_STATUS_SUCCESS is returned upon successful call.
 
  */
 rsmi_status_t rsmi_dev_pci_id_get(uint32_t dv_ind, uint64_t *bdfid);
@@ -371,7 +399,7 @@ rsmi_status_t rsmi_dev_pci_id_get(uint32_t dv_ind, uint64_t *bdfid);
  *  @param[inout] id a pointer to uint64_t to which the device id will be
  *  written
  *
- *  @retval RSMI_STATUS_SUCCESS is returned upon successful call.
+ *  @retval ::RSMI_STATUS_SUCCESS is returned upon successful call.
  *
  */
 rsmi_status_t rsmi_dev_id_get(uint32_t dv_ind, uint64_t *id);
@@ -382,15 +410,15 @@ rsmi_status_t rsmi_dev_id_get(uint32_t dv_ind, uint64_t *id);
  *  device index.
  *
  *  @details Given a device index @p dv_ind and a pointer to a uint32_t @p
- *  perf, this function will write the rsmi_dev_perf_level to the uint32_t
+ *  perf, this function will write the ::rsmi_dev_perf_level to the uint32_t
  *  pointed to by @p perf
  *
  *  @param[in] dv_ind a device index
  *
- *  @param[inout] perf a pointer to rsmi_dev_perf_level to which the
+ *  @param[inout] perf a pointer to ::rsmi_dev_perf_level to which the
  *  performance level will be written
  *
- *  @retval RSMI_STATUS_SUCCESS is returned upon successful call.
+ *  @retval ::RSMI_STATUS_SUCCESS is returned upon successful call.
  *
  */
 rsmi_status_t rsmi_dev_perf_level_get(uint32_t dv_ind,
@@ -408,7 +436,7 @@ rsmi_status_t rsmi_dev_perf_level_get(uint32_t dv_ind,
  *
  *  @param[in] perf_lvl the value to which the performance level should be set
  *
- *  @retval RSMI_STATUS_SUCCESS is returned upon successful call.
+ *  @retval ::RSMI_STATUS_SUCCESS is returned upon successful call.
  *
  */
 rsmi_status_t
@@ -427,7 +455,7 @@ rsmi_dev_perf_level_set(int32_t dv_ind, rsmi_dev_perf_level perf_lvl);
  *  @param[inout] od a pointer to uint32_t to which the overdrive percentage
  *  will be written
  *
- *  @retval RSMI_STATUS_SUCCESS is returned upon successful call.
+ *  @retval ::RSMI_STATUS_SUCCESS is returned upon successful call.
  *
  */
 rsmi_status_t rsmi_dev_overdrive_level_get(uint32_t dv_ind, uint32_t *od);
@@ -466,7 +494,7 @@ rsmi_status_t rsmi_dev_overdrive_level_get(uint32_t dv_ind, uint32_t *od);
  *
  *  @param[in] od the value to which the overdrive level should be set
  *
- *  @retval RSMI_STATUS_SUCCESS is returned upon successful call.
+ *  @retval ::RSMI_STATUS_SUCCESS is returned upon successful call.
  *
  */
 rsmi_status_t rsmi_dev_overdrive_level_set(int32_t dv_ind, uint32_t od);
@@ -476,7 +504,7 @@ rsmi_status_t rsmi_dev_overdrive_level_set(int32_t dv_ind, uint32_t od);
  *  specified clock type.
  *
  *  @details Given a device index @p dv_ind, a clock type @p clk_type, and a
- *  pointer to a to an rsmi_frequencies structure @p f, this function will
+ *  pointer to a to an ::rsmi_frequencies structure @p f, this function will
  *  fill in @p f with the possible clock speeds, and indication of the current
  *  clock speed selection.
  *
@@ -484,10 +512,10 @@ rsmi_status_t rsmi_dev_overdrive_level_set(int32_t dv_ind, uint32_t od);
  *
  *  @param[in] clk_type the type of clock for which the frequency is desired
  *
- *  @param[inout] f a pointer to a caller provided rsmi_frequencies structure
+ *  @param[inout] f a pointer to a caller provided ::rsmi_frequencies structure
  *  to which the frequency information will be written
  *
- *  @retval RSMI_STATUS_SUCCESS is returned upon successful call.
+ *  @retval ::RSMI_STATUS_SUCCESS is returned upon successful call.
  *
  */
 rsmi_status_t rsmi_dev_gpu_clk_freq_get(uint32_t dv_ind,
@@ -500,7 +528,7 @@ rsmi_status_t rsmi_dev_gpu_clk_freq_get(uint32_t dv_ind,
  * @details Given a device index @p dv_ind, a clock type @p clk_type, and a
  * 64 bit bitmask @p freq_bitmask, this function will limit the set of
  * allowable frequencies. If a bit in @p freq_bitmask has a value of 1, then
- * the frequency (as ordered in an rsmi_frequencies returned by
+ * the frequency (as ordered in an ::rsmi_frequencies returned by
  * rsmi_dev_get_gpu_clk_freq()) corresponding to that bit index will be
  * allowed.
  *
@@ -510,7 +538,7 @@ rsmi_status_t rsmi_dev_gpu_clk_freq_get(uint32_t dv_ind,
  * to get back to default state.
  *
  * All bits with indices greater than or equal to
- * rsmi_frequencies::num_supported will be ignored.
+ * ::rsmi_frequencies::num_supported will be ignored.
  *
  *  @param[in] dv_ind a device index
  *
@@ -519,7 +547,7 @@ rsmi_status_t rsmi_dev_gpu_clk_freq_get(uint32_t dv_ind,
  *
  *  @param[in] freq_bitmask A bitmask indicating the indices of the
  *  frequencies that are to be enabled (1) and disabled (0). Only the lowest
- *  rsmi_frequencies.num_supported bits of this mask are relevant.
+ *  ::rsmi_frequencies.num_supported bits of this mask are relevant.
  */
 rsmi_status_t rsmi_dev_gpu_clk_freq_set(uint32_t dv_ind,
                                rsmi_clk_type clk_type, uint64_t freq_bitmask);
@@ -537,7 +565,7 @@ rsmi_status_t rsmi_dev_gpu_clk_freq_set(uint32_t dv_ind,
  *
  *  @param[in] len the length of the caller provided buffer @p name.
  *
- *  @retval RSMI_STATUS_SUCCESS is returned upon successful call.
+ *  @retval ::RSMI_STATUS_SUCCESS is returned upon successful call.
  *
  */
 rsmi_status_t rsmi_dev_name_get(uint32_t dv_ind, char *name, size_t len);
@@ -559,7 +587,7 @@ rsmi_status_t rsmi_dev_name_get(uint32_t dv_ind, char *name, size_t len);
  *  @param[inout] temperature a pointer to int64_t to which the temperature
  *  will be written, in millidegrees Celcius.
  *
- *  @retval RSMI_STATUS_SUCCESS is returned upon successful call.
+ *  @retval ::RSMI_STATUS_SUCCESS is returned upon successful call.
  *
  */
 rsmi_status_t rsmi_dev_temp_metric_get(uint32_t dv_ind, uint32_t sensor_ind,
@@ -574,7 +602,7 @@ rsmi_status_t rsmi_dev_temp_metric_get(uint32_t dv_ind, uint32_t sensor_ind,
  * @param[in] sensor_ind a 0-based sensor index. Normally, this will be 0.
  * If a device has more than one sensor, it could be greater than 0.
  *
- * @retval RSMI_STATUS_SUCCESS is returned upon successful call.
+ * @retval ::RSMI_STATUS_SUCCESS is returned upon successful call.
  */
 rsmi_status_t rsmi_dev_fan_reset(uint32_t dv_ind, uint32_t sensor_ind);
 
@@ -594,7 +622,7 @@ rsmi_status_t rsmi_dev_fan_reset(uint32_t dv_ind, uint32_t sensor_ind);
  *  @param[inout] speed a pointer to uint32_t to which the speed will be
  *  written
  *
- *  @retval RSMI_STATUS_SUCCESS is returned upon successful call.
+ *  @retval ::RSMI_STATUS_SUCCESS is returned upon successful call.
  *
  */
 rsmi_status_t rsmi_dev_fan_rpms_get(uint32_t dv_ind, uint32_t sensor_ind,
@@ -620,7 +648,7 @@ rsmi_status_t rsmi_dev_fan_rpms_get(uint32_t dv_ind, uint32_t sensor_ind,
  * @param[inout] speed a pointer to uint32_t to which the speed will be
  * written
  *
- * @retval RSMI_STATUS_SUCCESS is returned upon successful call.
+ * @retval ::RSMI_STATUS_SUCCESS is returned upon successful call.
  *
  */
 rsmi_status_t rsmi_dev_fan_speed_get(uint32_t dv_ind,
@@ -641,7 +669,7 @@ rsmi_status_t rsmi_dev_fan_speed_get(uint32_t dv_ind,
  *  @param[inout] max_speed a pointer to uint32_t to which the maximum speed
  *  will be written
  *
- *  @retval RSMI_STATUS_SUCCESS is returned upon successful call.
+ *  @retval ::RSMI_STATUS_SUCCESS is returned upon successful call.
  *
  */
 rsmi_status_t rsmi_dev_fan_speed_max_get(uint32_t dv_ind,
@@ -663,7 +691,7 @@ rsmi_status_t rsmi_dev_fan_speed_max_get(uint32_t dv_ind,
  *
  * @param[in] speed the speed to which the function will attempt to set the fan
  *
- * @retval RSMI_STATUS_SUCCESS is returned upon successful call.
+ * @retval ::RSMI_STATUS_SUCCESS is returned upon successful call.
  */
 rsmi_status_t rsmi_dev_fan_speed_set(uint32_t dv_ind, uint32_t sensor_ind,
                                                               uint64_t speed);
@@ -686,7 +714,7 @@ rsmi_status_t rsmi_dev_fan_speed_set(uint32_t dv_ind, uint32_t sensor_ind,
  *  @param[inout] power a pointer to uint64_t to which the average power
  *  consumption will be written
  *
- *  @retval RSMI_STATUS_SUCCESS is returned upon successful call.
+ *  @retval ::RSMI_STATUS_SUCCESS is returned upon successful call.
  *
  */
 rsmi_status_t
@@ -708,7 +736,7 @@ rsmi_dev_power_ave_get(uint32_t dv_ind, uint32_t sensor_ind, uint64_t *power);
  *  @param[inout] cap a pointer to a uint64_t that indicates the power cap,
  *  in microwatts
  *
- *  @retval RSMI_STATUS_SUCCESS is returned upon successful call.
+ *  @retval ::RSMI_STATUS_SUCCESS is returned upon successful call.
  *
  */
 rsmi_status_t
@@ -731,7 +759,7 @@ rsmi_dev_power_cap_get(uint32_t dv_ind, uint32_t sensor_ind, uint64_t *cap);
  *  @param[inout] min a pointer to a uint64_t that indicates the minimum
  *  possible power cap, in microwatts
  *
- *  @retval RSMI_STATUS_SUCCESS is returned upon successful call.
+ *  @retval ::RSMI_STATUS_SUCCESS is returned upon successful call.
  *
  */
 rsmi_status_t
@@ -753,7 +781,7 @@ rsmi_dev_power_cap_range_get(uint32_t dv_ind, uint32_t sensor_ind,
  *  @param[inout] cap a uint64_t that indicates the desired power cap, in
  *  microwatts
  *
- *  @retval RSMI_STATUS_SUCCESS is returned upon successful call.
+ *  @retval ::RSMI_STATUS_SUCCESS is returned upon successful call.
  *
  */
 rsmi_status_t
@@ -776,7 +804,7 @@ rsmi_dev_power_cap_set(uint32_t dv_ind, uint32_t sensor_ind, uint64_t cap);
  *  @param[inout] power a pointer to uint64_t to which the maximum power
  *  consumption will be written
  *
- *  @retval RSMI_STATUS_SUCCESS is returned upon successful call.
+ *  @retval ::RSMI_STATUS_SUCCESS is returned upon successful call.
  *
  */
 rsmi_status_t
@@ -807,7 +835,7 @@ rsmi_dev_power_max_get(uint32_t dv_ind, uint32_t sensor_ind, uint64_t *power);
  * @param[inout] status a pointer to rsmi_power_profile_status that will be
  * populated by a call to this function
  *
- *  @retval RSMI_STATUS_SUCCESS is returned upon successful call.
+ *  @retval ::RSMI_STATUS_SUCCESS is returned upon successful call.
  *
  */
 rsmi_status_t
@@ -831,7 +859,7 @@ rsmi_dev_power_profile_presets_get(uint32_t dv_ind, uint32_t sensor_ind,
  * @param[in] profile a rsmi_power_profile_preset_masks that hold the mask
  * of the desired new power profile
  *
- * @retval RSMI_STATUS_SUCCESS is returned upon successful call.
+ * @retval ::RSMI_STATUS_SUCCESS is returned upon successful call.
  *
  */
 rsmi_status_t
@@ -848,30 +876,27 @@ rsmi_dev_power_profile_set(uint32_t dv_ind, uint32_t sensor_ind,
  * @param[inout] status_string A pointer to a const char * which will be made
  * to point to a description of the provided error code
  *
- * @retval RSMI_STATUS_SUCCESS is returned upon successful call
+ * @retval ::RSMI_STATUS_SUCCESS is returned upon successful call
  *
  */
 rsmi_status_t
 rsmi_status_string(rsmi_status_t status, const char **status_string);
 
 /**
- * @brief Get percentage of time device is busy doing any processing
- *
- * @details Given a device index @p dv_ind, this function returns the
- * percentage of time that the specified device is busy. The device is
- * considered busy if any one or more of its sub-blocks are working, and idle
- * if none of the sub-blocks are working.
- *
- * @param[in] dv_ind a device index
- *
- * @param[inout] busy_percent a pointer to the uint32_t to which the busy
- * percent will be written
- *
- * @retval RSMI_STATUS_SUCCESS is returned upon successful call
- *
+ * @brief Get the build version information for the currently running build of
+ * RSMI.
+ * 
+ * @details  Get the major, minor, patch and build string for RSMI build
+ * currently in use through @p version
+ * 
+ * @paramp[inout] version A pointer to an ::rsmi_version structure that will
+ * be updated with the version information upon return.
+ * 
+ * @retval ::RSMI_STATUS_SUCCESS is returned upon successful call
+ * 
  */
 rsmi_status_t
-rsmi_dev_busy_percent_get(uint32_t dv_ind, uint32_t *busy_percent);
+rsmi_version_get(rsmi_version *version);
 
 #ifdef __cplusplus
 }

--- a/src/rocm_smi.cc
+++ b/src/rocm_smi.cc
@@ -59,6 +59,7 @@
 #include "rocm_smi/rocm_smi_device.h"
 #include "rocm_smi/rocm_smi_utils.h"
 #include "rocm_smi/rocm_smi_exception.h"
+#include "rocm_smi/rocm_smi64Config.h"
 
 static const uint32_t kMaxOverdriveLevel = 20;
 
@@ -1112,6 +1113,23 @@ rsmi_dev_busy_percent_get(uint32_t dv_ind, uint32_t *busy_percent) {
   errno = 0;
   *busy_percent = strtoul(val_str.c_str(), nullptr, 10);
   assert(errno == 0);
+
+  return RSMI_STATUS_SUCCESS;
+
+  CATCH
+}
+
+rsmi_status_t
+rsmi_version_get(rsmi_version *version) {
+  TRY
+
+  if (version == nullptr) {
+    return RSMI_STATUS_INVALID_ARGS;
+  }
+  version->major = rocm_smi_VERSION_MAJOR;
+  version->minor = rocm_smi_VERSION_MINOR;
+  version->patch = rocm_smi_VERSION_PATCH;
+  version->build = rocm_smi_VERSION_BUILD;
 
   return RSMI_STATUS_SUCCESS;
 

--- a/src/rocm_smi64Config.in
+++ b/src/rocm_smi64Config.in
@@ -1,0 +1,56 @@
+/*
+ * =============================================================================
+ *   ROC Runtime Conformance Release License
+ * =============================================================================
+ * The University of Illinois/NCSA
+ * Open Source License (NCSA)
+ *
+ * Copyright (c) 2017, Advanced Micro Devices, Inc.
+ * All rights reserved.
+ *
+ * Developed by:
+ *
+ *                 AMD Research and AMD ROC Software Development
+ *
+ *                 Advanced Micro Devices, Inc.
+ *
+ *                 www.amd.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal with the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ *  - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimers.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimers in
+ *    the documentation and/or other materials provided with the distribution.
+ *  - Neither the names of <Name of Development Group, Name of Institution>,
+ *    nor the names of its contributors may be used to endorse or promote
+ *    products derived from this Software without specific prior written
+ *    permission.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS WITH THE SOFTWARE.
+ *
+ */
+
+#ifndef INCLUDE_ROCM_SMI_ROCM_SMI64CONFIG_H_
+#define INCLUDE_ROCM_SMI_ROCM_SMI64CONFIG_H_
+
+// This file is generated on build.
+
+#define rocm_smi_VERSION_MAJOR @rocm_smi_VERSION_MAJOR@
+#define rocm_smi_VERSION_MINOR @rocm_smi_VERSION_MINOR@
+#define rocm_smi_VERSION_PATCH @rocm_smi_VERSION_PATCH@
+#define rocm_smi_VERSION_BUILD "@rocm_smi_VERSION_BUILD@"
+
+#endif  // INCLUDE_ROCM_SMI_ROCM_SMI64CONFIG_H_

--- a/tests/rocm_smi_test/functional/rsmi_sanity.cc
+++ b/tests/rocm_smi_test/functional/rsmi_sanity.cc
@@ -501,7 +501,7 @@ static rsmi_status_t test_set_pci_bw(uint32_t dv_ind) {
   return RSMI_STATUS_SUCCESS;
 }
 
-static void print_frequencies(rsmi_frequencies *f, uint32_t *l=nullptr) {
+static void print_frequencies(rsmi_frequencies *f, uint32_t *l = nullptr) {
   assert(f != nullptr);
   for (uint32_t j = 0; j < f->num_supported; ++j) {
     std::cout << "\t**  " << j << ": " << f->frequency[j];
@@ -557,8 +557,19 @@ void TestSanity::Run(void) {
   rsmi_dev_perf_level pfl;
   rsmi_frequencies f;
   rsmi_pcie_bandwidth b;
-
+  rsmi_version ver = {0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, nullptr};
   uint32_t num_monitor_devs = 0;
+
+  err = rsmi_version_get(&ver);
+  CHK_ERR_ASRT(err)
+
+  ASSERT_TRUE(ver.major != 0xFFFFFFFF && ver.minor != 0xFFFFFFFF &&
+                             ver.patch != 0xFFFFFFFF && ver.build != nullptr);
+
+  IF_VERB(STANDARD) {
+    std::cout << "\t**RocM SMI Library version: " << ver.major << "." <<
+       ver.minor << "." << ver.patch << " (" << ver.build << ")" << std::endl;
+  }
 
   for (uint32_t i = 0; i < num_iteration(); i++) {
     IF_VERB(PROGRESS) {


### PR DESCRIPTION
We are starting to use semantic versioning (semver.org) to manage how changes to the ABI are versioned. In conjunction with that, this change will allow the caller to get the version of rocm_smi_lib at runtime.