### PR TITLE
More general solution to api support hwmon mapping

### DIFF
--- a/include/rocm_smi/rocm_smi.h
+++ b/include/rocm_smi/rocm_smi.h
@@ -326,7 +326,8 @@ typedef enum {
                                                //!< temperature
   RSMI_TEMP_TYPE_MEMORY,                       //!< VRAM temperature
 
-  RSMI_TEMP_TYPE_LAST = RSMI_TEMP_TYPE_MEMORY
+  RSMI_TEMP_TYPE_LAST = RSMI_TEMP_TYPE_MEMORY,
+  RSMI_TEMP_TYPE_INVALID = 0xFFFFFFFF          //!< Invalid type
 } rsmi_temperature_type_t;
 
 /**

--- a/include/rocm_smi/rocm_smi_common.h
+++ b/include/rocm_smi/rocm_smi_common.h
@@ -93,6 +93,10 @@ struct RocmSMI_env_vars {
     const char *path_power_root_override;
 };
 
+// Use this bit offset to store the label-mapped file index
+#define MONITOR_TYPE_BIT_POSITION 16
+#define MONITOR_IND_BIT_MASK ((1 << MONITOR_TYPE_BIT_POSITION) - 1)
+
 // Support information data structures
 typedef std::vector<uint64_t> SubVariant;
 typedef SubVariant::const_iterator SubVariantIt;

--- a/include/rocm_smi/rocm_smi_monitor.h
+++ b/include/rocm_smi/rocm_smi_monitor.h
@@ -93,7 +93,8 @@ class Monitor {
     int readMonitor(MonitorTypes type, uint32_t sensor_ind, std::string *val);
     int writeMonitor(MonitorTypes type, uint32_t sensor_ind, std::string val);
     uint32_t setSensorLabelMap(void);
-    uint32_t getSensorIndex(rsmi_temperature_type_t type);
+    uint32_t getTempSensorIndex(rsmi_temperature_type_t type);
+    rsmi_temperature_type_t getTempSensorEnum(uint64_t ind);
     void fillSupportedFuncs(SupportedFuncMap *supported_funcs);
 
  private:
@@ -101,6 +102,15 @@ class Monitor {
     std::string path_;
     const RocmSMI_env_vars *env_;
     std::map<rsmi_temperature_type_t, uint32_t> temp_type_index_map_;
+
+    // This map uses a 64b index instead of 32b (unlike temp_type_index_map_)
+    // for flexibility and simplicity. Currently, some parts of the
+    // implementation store both the RSMI api index and the file index into a
+    // single value. 32 bits is enough to store both, but we are using 64
+    // bits for simpler integration with existing implementation, which uses
+    // a 64b value. Also, if we need to encode anything else, 64b will give
+    // us more room to do so, without excessive changes.
+    std::map<uint64_t, rsmi_temperature_type_t> index_temp_type_map_;
 };
 
 }  // namespace smi

--- a/src/rocm_smi.cc
+++ b/src/rocm_smi.cc
@@ -1892,15 +1892,10 @@ rsmi_dev_temp_metric_get(uint32_t dv_ind, uint32_t sensor_type,
   assert(dev->monitor() != nullptr);
   std::shared_ptr<amd::smi::Monitor> m = dev->monitor();
 
-  uint32_t err  = m->setSensorLabelMap();
-  if (err) {
-     return errno_to_rsmi_status(err);
-  }
-
-  // getSensorIndex will throw an out of range exception if sensor_type is not
-  // found
+  // getTempSensorIndex will throw an out of range exception if sensor_type is
+  // not found
   uint32_t sensor_index =
-         m->getSensorIndex(static_cast<rsmi_temperature_type_t>(sensor_type));
+     m->getTempSensorIndex(static_cast<rsmi_temperature_type_t>(sensor_type));
 
   CHK_API_SUPPORT_ONLY(temperature, metric, sensor_index)
 
@@ -3072,12 +3067,9 @@ rsmi_func_iter_value_get(rsmi_func_id_iter_handle_t handle,
     case SUBVARIANT_ITER:
       sub_var_itr = reinterpret_cast<SubVariantIt *>(handle->func_id_iter);
 
-      // The sub-variant refers to monitors types. We store those as the exist
-      // in the file name. For example, for temp2_crit, 2 is stored (crit is the
-      // variant). These are 1-based values. But the RSMI user expects a 0-based
-      // value, so we will convert it to RSMI-space by subracting 1:
-      assert(*(*sub_var_itr) > 0);
-      value->id = *(*sub_var_itr) - 1;
+      // The hwmon file index that is appropriate for the rsmi user is stored
+      // at bit position MONITOR_TYPE_BIT_POSITION.
+      value->id = *(*sub_var_itr) >> MONITOR_TYPE_BIT_POSITION;
       break;
 
     default:

--- a/src/rocm_smi_device.cc
+++ b/src/rocm_smi_device.cc
@@ -880,6 +880,19 @@ void Device::fillSupportedFuncs(void) {
   // DumpSupportedFunctions();
 }
 
+static bool subvariant_match(const std::shared_ptr<SubVariant> *sv,
+                                                             uint64_t sub_v) {
+  assert(sv != nullptr);
+
+  SubVariantIt it = (*sv)->begin();
+  for (; it != (*sv)->end(); it++) {
+    if ((*it & MONITOR_IND_BIT_MASK) == sub_v) {
+      return true;
+    }
+  }
+  return false;
+}
+
 bool Device::DeviceAPISupported(std::string name, uint64_t variant,
                                                        uint64_t sub_variant) {
   SupportedFuncMapIt func_it;
@@ -908,13 +921,7 @@ bool Device::DeviceAPISupported(std::string name, uint64_t variant,
       // if variant is != RSMI_DEFAULT_VARIANT, we should not have a nullptr
       assert(var_it->second != nullptr);
 
-      sub_var_it = std::find(var_it->second->begin(),
-                                          var_it->second->end(), sub_variant);
-      if (sub_var_it == var_it->second->end()) {
-        return false;
-      } else {
-        return true;
-      }
+      return subvariant_match(&(var_it->second), sub_variant);
     }
   } else {  // variant == RSMI_DEFAULT_VARIANT
     if (func_it->second != nullptr) {
@@ -926,13 +933,7 @@ bool Device::DeviceAPISupported(std::string name, uint64_t variant,
       if (func_it->second == nullptr) {
         return false;
       }
-      sub_var_it = std::find(var_it->second->begin(),
-                                          var_it->second->end(), sub_variant);
-      if (sub_var_it == var_it->second->end()) {
-        return false;
-      } else {
-        return true;
-      }
+      return subvariant_match(&(var_it->second), sub_variant);
     }
   }
   assert(!"We should not reach here");

--- a/src/rocm_smi_main.cc
+++ b/src/rocm_smi_main.cc
@@ -481,8 +481,10 @@ uint32_t RocmSMI::DiscoverAMDMonitors(void) {
       fs.close();
 
       if (amd_monitor_types_.find(mon_type) != amd_monitor_types_.end()) {
-        monitors_.push_back(std::shared_ptr<Monitor>(
-                                          new Monitor(mon_name, &env_vars_)));
+        std::shared_ptr<Monitor> m =
+                  std::shared_ptr<Monitor>(new Monitor(mon_name, &env_vars_));
+        m->setSensorLabelMap();
+        monitors_.push_back(m);
       }
     }
     dentry = readdir(mon_dir);


### PR DESCRIPTION
This solution takes into account that some hwmons use
label files to map sensor types. The previous solution
did not take this into account.

Change-Id: I1d6204573cefa8197b2cfe0ffb412b545df3d80a