### PR TITLE
Require gcc version 5.4.0 or greater

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,12 @@ set(CPACK_PACKAGE_FILE_NAME "${ROCM_SMI_PACKAGE}-${PKG_VERSION_STR}")
 ## Verbose output.
 set(CMAKE_VERBOSE_MAKEFILE on)
 
+if (CMAKE_COMPILER_IS_GNUCC AND
+                         CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.4.0)
+    message("Compiler version is " ${CMAKE_CXX_COMPILER_VERSION})
+    message(FATAL_ERROR "Require at least gcc-5.4.0")
+endif()
+
 ## Compiler flags
 set(CMAKE_CXX_FLAGS
  "${CMAKE_CXX_FLAGS} -Wall -Wextra -fno-rtti -m64 -msse -msse2 -std=c++11 ")


### PR DESCRIPTION
To avoid build and runtime issues, we should set a minimum
compiler version. std::regex, used by rocm_smi_lib, requires
4.9.0 or greater. However, the development and test
environments are (mainly) 5.4.0.

Change-Id: Ie18e9f905786ec8eb50d61a326cb45173a0ec355