### PR TITLE
Use PID for unique mutex name in /dev/shm

### DIFF
--- a/src/rocm_smi_device.cc
+++ b/src/rocm_smi_device.cc
@@ -493,7 +493,9 @@ Device::Device(std::string p, RocmSMI_env_vars const *e) :
   size_t i = path_.rfind('/', path_.length());
   std::string dev = path_.substr(i + 1, path_.length() - i);
 
-  std::string m_name("/rocm_smi_");
+  pid_t pid = getpid();
+
+  std::string m_name("/rocm_smi_"+std::to_string(pid)+"_");
   m_name += dev;
 
   mutex_ = shared_mutex_init(m_name.c_str(), 0777);


### PR DESCRIPTION
Fixes a race condition if the library is simultaneously invoked from multiple processes

fixes #88 