### PR TITLE
enable machine specific flags on x86_64 only

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,8 +64,13 @@ if (CMAKE_COMPILER_IS_GNUCC AND
 endif()
 
 ## Compiler flags
-set(CMAKE_CXX_FLAGS
- "${CMAKE_CXX_FLAGS} -Wall -Wextra -fno-rtti -m64 -msse -msse2 -std=c++11 ")
+if (${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL "x86_64")
+    set(CMAKE_CXX_FLAGS
+     "${CMAKE_CXX_FLAGS} -Wall -Wextra -fno-rtti -m64 -msse -msse2 -std=c++11 ")
+else ()
+    set(CMAKE_CXX_FLAGS
+     "${CMAKE_CXX_FLAGS} -Wall -Wextra -fno-rtti -std=c++11 ")
+endif ()
 # Security options
 set(CMAKE_CXX_FLAGS
  "${CMAKE_CXX_FLAGS} -Wconversion -Wcast-align ")


### PR DESCRIPTION
When attempting to build on non x86_64 targets, the compiler chokes on
the -m* machine specific flags, which work only with x86_64
processors.  This change allows non x86_64 to build rocm_smi_lib with
their own generic options without altering the behavior for x86_64
targets.

Signed-off-by: Étienne Mollier <emollier@debian.org>