### PR TITLE
Fixing VRAM reporting with --json set

### DIFF
--- a/python_smi_tools/rocm_smi.py
+++ b/python_smi_tools/rocm_smi.py
@@ -1802,9 +1802,15 @@ def showMemUse(deviceList):
     memoryUse = c_uint64()
     printLogSpacer(' Current Memory Use ')
     for device in deviceList:
-        ret = rocmsmi.rsmi_dev_memory_busy_percent_get(device, byref(memoryUse))
-        if rsmi_ret_ok(ret, device, '% memory use'):
-            printLog(device, 'GPU memory use (%)', memoryUse.value)
+        memInfo = getMemInfo(device, 'vram')
+        if memInfo[0] == None or memInfo[1] == None:
+            ret = 'N/A'
+        else:
+            ret = str((100 * (float(memInfo[0]) / float(memInfo[1]))))
+
+        printLog(device, 'GPU memory use (%)', ret)
+        printLog(device, 'GPU memory use', memInfo[0])
+        printLog(device, 'GPU memory available', memInfo[1])
         util_counters = getCoarseGrainUtil(device, "Memory Activity")
         if util_counters != -1:
             for ut_counter in util_counters:


### PR DESCRIPTION
This is a fix for getting accurate VRAM readings when the --json flag

Before the change, when running `rocm-smi --json --showmemuse` i get:
```json
{
  "card0": {
    "GPU memory use (%)": "0",
    "Memory Activity": "N/A"
  },
  "card1": {
    "GPU memory use (%)": "0",
    "Memory Activity": "N/A"
  }
}
```

After this fix i get:
```json
{
  "card0": {
    "GPU memory use (%)": "0.10168946267106549",
    "GPU memory use": "17453056",
    "GPU memory available": "17163091968",
    "Memory Activity": "N/A"
  },
  "card1": {
    "GPU memory use (%)": "0.10171332783479961",
    "GPU memory use": "17457152",
    "GPU memory available": "17163091968",
    "Memory Activity": "N/A"
  }
}
```

I have only tested locally with 2 RX6800s and:
AMD ROCm System Management Interface | ROCM-SMI version: 1.4.1 | Kernel version: 5.18.13

If interested, I needed this to set up a prometheus exporter in python: https://github.com/jerome3o/rocm-prom-metrics

Let me know if there is anything I can do to help get this merged :)