### PR TITLE
Add support for setting stable/profile perf levels

### DIFF
--- a/python_smi_tools/README.md
+++ b/python_smi_tools/README.md
@@ -199,6 +199,10 @@ Output options:
         low (Keep values low, regardless of workload)
         high (Keep values high, regardless of workload)
         manual (Only use values defined by --setsclk and --setmclk)
+        stable_std (set sclk and mclk to fixed value for profiling)
+        stable_peak (set sclk and mclk to maximum for profiling)
+        stable_min_mclk (set mclk to minimum for profiling)
+        stable_min_sclk (set sclk to minimum for profiling)
 
 --setoverdrive/--setmemoverdrive #:
     ***DEPRECATED IN NEWER KERNEL VERSIONS (use --setslevel/--setmlevel instead)***

--- a/python_smi_tools/rocm_smi.py
+++ b/python_smi_tools/rocm_smi.py
@@ -1296,7 +1296,8 @@ def setPerformanceLevel(deviceList, level):
     @param level: Performance Level to set
     """
     printLogSpacer(' Set Performance Level ')
-    validLevels = ['auto', 'low', 'high', 'manual']
+    validLevels = ['auto', 'low', 'high', 'manual',
+                   'stable_std', 'stable_peak', 'stable_min_mclk', 'stable_min_sclk']
     for device in deviceList:
         if level not in validLevels:
             printErrLog(device, 'Unable to set Performance Level')


### PR DESCRIPTION
in sysfs, these are called profile\_\* instead of stable\_\*, but this PR adheres to the rocm_smi_lib convention of stable_*.