### PR TITLE
remove const for ScopeGuard operator

### DIFF
--- a/include/rocm_smi/rocm_smi_utils.h
+++ b/include/rocm_smi/rocm_smi_utils.h
@@ -216,7 +216,7 @@ class ScopeGuard {
   __forceinline ~ScopeGuard() {
     if (!dismiss_) release_();
   }
-  __forceinline ScopeGuard& operator=(const ScopeGuard& rhs) {
+  __forceinline ScopeGuard& operator=(ScopeGuard& rhs) {
     dismiss_ = rhs.dismiss_;
     release_ = rhs.release_;
     rhs.dismiss_ = true;


### PR DESCRIPTION
With gcc 14 on Fedora rawhide, there is this build error

[  3%] Building CXX object rocm_smi/CMakeFiles/rocm_smi64.dir/__/src/rocm_smi_device.cc.o In file included from rocm_smi_lib/src/rocm_smi_device.cc:67: rocm_smi_lib/include/rocm_smi/rocm_smi_utils.h: In member function ‘amd::smi::ScopeGuard<lambda>& amd::smi::ScopeGuard<lambda>::operator=(const amd::smi::ScopeGuard<lambda>&)’: /home/trix/rocm/rocm_smi_lib/include/rocm_smi/rocm_smi_utils.h:222:18: error: assignment of member ‘dismiss_’ in read-only object
  222 |     rhs.dismiss_ = true;
      |     ~~~~~~~~~~~~~^~~~~~

The rhs parameter can not be const and setting a sideeffect. So remove const