### PR TITLE
change CMAKE_HOST_SYSTEM_PROCESSOR to CMAKE_SYSTEM_PROCESSOR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,7 @@ endif()
 ## Compiler flags
 set(CMAKE_CXX_FLAGS
  "${CMAKE_CXX_FLAGS} -Wall -Wextra -fno-rtti")
-if (${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL "x86_64")
+if (${CMAKE_SYSTEM_PROCESSOR} STREQUAL "x86_64")
     set(CMAKE_CXX_FLAGS
      "${CMAKE_CXX_FLAGS} -m64 -msse -msse2")
 endif()


### PR DESCRIPTION
Fixes build failure when cross compiling.

This should be CMAKE_SYSTEM_PROCESSOR, which will default to CMAKE_HOST_SYSTEM_PROCESSOR when not cross compiling

https://cmake.org/cmake/help/latest/variable/CMAKE_SYSTEM_PROCESSOR.html
https://cmake.org/cmake/help/latest/variable/CMAKE_HOST_SYSTEM_PROCESSOR.html

Tested cross compiling to aarch64, armv6l, and armv7l (although its extremely unlikely that 32-bit arm will ever use this library)
