### PR TITLE
Fix issue: 162 (typo)

### DIFF
--- a/include/rocm_smi/rocm_smi.h
+++ b/include/rocm_smi/rocm_smi.h
@@ -1290,7 +1290,7 @@ rsmi_status_t rsmi_dev_revision_get(uint32_t dv_ind, uint16_t *revision);
  *  @retval ::RSMI_STATUS_INVALID_ARGS the provided arguments are not valid
  *
  */
-rsmi_status_t rsmi_dev_sku_get(uint32_t dv_ind, char *sku);
+rsmi_status_t rsmi_dev_sku_get(uint32_t dv_ind, uint16_t *sku);
 
 /**
  *  @brief Get the device vendor id associated with the device with provided


### PR DESCRIPTION
Fix for issue: https://github.com/ROCm/rocm_smi_lib/issues/162

There is a difference in argument types between declaration and definition.
This made the function unusable.

**Files affected:**
- rocm_smi.h