### PR TITLE
fix(python): fix comparison to None

### DIFF
--- a/python_smi_tools/rocm_smi.py
+++ b/python_smi_tools/rocm_smi.py
@@ -467,7 +467,7 @@ def getAllocatedMemoryPercent(device):
     mem_use_pct = 0
     if vram_used is None:
         return allocated_memory_vram
-    if vram_used != None and vram_total != None and float(vram_total) != 0:
+    if vram_used is not None and vram_total is not None and float(vram_total) != 0:
         # take floor of result (round down to nearest integer)
         mem_use_pct = (100 * (float(vram_used) / float(vram_total))) // 1
         allocated_memory_vram['value'] = mem_use_pct
@@ -522,7 +522,7 @@ def getProcessName(pid):
     except subprocess.CalledProcessError as e:
         pName = 'UNKNOWN'
 
-    if pName == None:
+    if pName is None:
         pName = 'UNKNOWN'
 
     # Remove the substrings surrounding from process name (b' and \n')
@@ -2406,7 +2406,7 @@ def getCoarseGrainUtil(device, typeName=None):
     """
     timestamp = c_uint64(0)
 
-    if typeName != None:
+    if typeName is not None:
 
         try:
             i = utilization_counter_name.index(typeName)
@@ -3317,7 +3317,7 @@ def showWeightTopology(deviceList):
         for gpu2 in deviceList:
             if (gpu1 == gpu2):
                 printTableRow('%-12s', '0')
-            elif (gpu_links_weight[gpu1][gpu2] == None):
+            elif (gpu_links_weight[gpu1][gpu2] is None):
                 printTableRow('%-12s', 'N/A')
             else:
                 printTableRow('%-12s', gpu_links_weight[gpu1][gpu2].value)
@@ -3363,7 +3363,7 @@ def showHopsTopology(deviceList):
         for gpu2 in deviceList:
             if (gpu1 == gpu2):
                 printTableRow('%-12s', '0')
-            elif (gpu_links_hops[gpu1][gpu2] == None):
+            elif (gpu_links_hops[gpu1][gpu2] is None):
                 printTableRow('%-12s', 'N/A')
             else:
                 printTableRow('%-12s', gpu_links_hops[gpu1][gpu2].value)
@@ -4150,7 +4150,7 @@ if __name__ == '__main__':
         showPcieReplayCount(deviceList)
     if args.showserial:
         showSerialNumber(deviceList)
-    if args.showpids != None:
+    if args.showpids is not None:
         showPids(args.showpids)
     if args.showpidgpus or str(args.showpidgpus) == '[]':
         showGpusByPid(args.showpidgpus)

--- a/python_smi_tools/rsmiBindings.py.in
+++ b/python_smi_tools/rsmiBindings.py.in
@@ -23,7 +23,7 @@ def initRsmiBindings(silent=False):
             print(args)
 
     rocm_smi_lib_path = os.getenv('ROCM_SMI_LIB_PATH')
-    if (rocm_smi_lib_path != None):
+    if (rocm_smi_lib_path is not None):
         path_librocm = rocm_smi_lib_path
     else:
         path_librocm = os.path.dirname(os.path.realpath(__file__)) + '/../../@CMAKE_INSTALL_LIBDIR@/librocm_smi64.so.@VERSION_MAJOR@'

--- a/python_smi_tools/rsmiBindingsInit.py.in
+++ b/python_smi_tools/rsmiBindingsInit.py.in
@@ -23,7 +23,7 @@ def initRsmiBindings(silent=False):
             print(args)
 
     rocm_smi_lib_path = os.getenv('ROCM_SMI_LIB_PATH')
-    if (rocm_smi_lib_path != None):
+    if (rocm_smi_lib_path is not None):
         path_librocm = rocm_smi_lib_path
     else:
         path_librocm = os.path.dirname(os.path.realpath(__file__)) + '/../../@CMAKE_INSTALL_LIBDIR@/librocm_smi64.so.@VERSION_MAJOR@'


### PR DESCRIPTION
from PEP8 (https://peps.python.org/pep-0008/#programming-recommendations):

> Comparisons to singletons like None should always be done with is or is not, never the equality operators.