### PR TITLE
Update rocm_smi_device.cc to delete duplicate content

### DIFF
--- a/src/rocm_smi_device.cc
+++ b/src/rocm_smi_device.cc
@@ -506,7 +506,6 @@ static const std::map<const char *, dev_depends_t> kDevFuncDependsMap = {
   {"rsmi_dev_counter_create",            {{}, {}}},
   {"rsmi_dev_xgmi_error_status",         {{kDevXGMIErrorFName}, {}}},
   {"rsmi_dev_xgmi_error_reset",          {{kDevXGMIErrorFName}, {}}},
-  {"rsmi_dev_memory_reserved_pages_get", {{kDevMemPageBadFName}, {}}},
   {"rsmi_topo_numa_affinity_get",        {{kDevNumaNodeFName}, {}}},
   {"rsmi_dev_gpu_metrics_info_get",      {{kDevGpuMetricsFName}, {}}},
   {"rsmi_dev_gpu_reset",                 {{kDevGpuResetFName}, {}}},


### PR DESCRIPTION
It has the duplicate content in line 488 in the same file.
(line 488 and 509: {"vsmi_dev_memory_reserved_pages_get", {{kDevMemPageBadFName}, {}}}, )