### PR TITLE
Fix `‘uint64_t’ does not name a type` in gcc-15

### DIFF
--- a/include/rocm_smi/rocm_smi_common.h
+++ b/include/rocm_smi/rocm_smi_common.h
@@ -45,6 +45,7 @@
 #ifndef INCLUDE_ROCM_SMI_ROCM_SMI_COMMON_H_
 #define INCLUDE_ROCM_SMI_ROCM_SMI_COMMON_H_
 
+#include <cstdint>
 #include <memory>
 #include <map>
 #include <vector>


### PR DESCRIPTION
Common C++ headers (like `<memory>`) in GCC 15.0.0 (combined with libstdc++) don't transitively include `uint64_t` anymore.

Minimal reproducer: https://godbolt.org/z/dqGbnG8bY

Closes #191