### PR TITLE
Fix warnings on CXX/linker flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,7 @@ set(CMAKE_CXX_FLAGS
 
 # Clang does not set the build-id
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    set (CMAKE_SHARED_LINKER_FLAGS "-Wl,--build-id=sha1")
+    set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--build-id=sha1")
 endif()
 
 # Use this instead of above for 32 bit
@@ -129,10 +129,16 @@ else ()
     set(CMAKE_CXX_FLAGS
       "${CMAKE_CXX_FLAGS} -DFORTIFY_SOURCE=2 -fstack-protector-all -Wcast-align")
     ## More security breach mitigation flags
-    set(CMAKE_CXX_FLAGS
-      "${CMAKE_CXX_FLAGS} -Wl,-z,noexecstack -Wl,-znoexecheap -Wl,-z,relro ")
-    set(CMAKE_CXX_FLAGS
-      "${CMAKE_CXX_FLAGS} -Wtrampolines -Wl,-z,now")
+    set(HARDENING_LDFLAGS
+      "${HARDENING_LDFLAGS} -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${HARDENING_LDFLAGS}")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${HARDENING_LDFLAGS}")
+
+    include(CheckCXXCompilerFlag)
+    check_cxx_compiler_flag("-Wtrampolines" CXX_SUPPORTS_WTRAMPOLINES)
+    if (CXX_SUPPORTS_WTRAMPOLINES)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wtrampolines")
+    endif ()
 endif ()
 
 set(COMMON_SRC_DIR "${PROJECT_SOURCE_DIR}/src")


### PR DESCRIPTION
1) When `clang` is used as system compiler, libraries were built without respecting LDFLAGS. For example, this affected LTO flags, if any (and it only affected clang, not gcc).

2) Linker flags are registered as CXX flags, which produces warnings during compilation:
```
clang++: warning: -Wl,-z,noexecstack: 'linker' input unused [-Wunused-command-line-argument]
clang++: warning: -Wl,-znoexecheap: 'linker' input unused [-Wunused-command-line-argument]
clang++: warning: -Wl,-z,relro: 'linker' input unused [-Wunused-command-line-argument]
clang++: warning: -Wl,-z,now: 'linker' input unused [-Wunused-command-line-argument]
```

3) Clang does not support `-Wtrampolines` flag:
```
warning: unknown warning option '-Wtrampolines' [-Wunknown-warning-option]
```

4) No linkers support `noexecheap` anymore. `noexecheap` linker flag was a part of PaX patches to GNU ld, [which were dropped in 2017](https://www.gentoo.org/support/news-items/2017-08-19-hardened-sources-removal.html). Now ld/ld.lld/ld.gold don't support it and protection of heap is managed by NX bit. Therefore every compiler produces this warning:
```
ld.lld: warning: unknown -z value: noexecheap
```

Closes #210.