### PR TITLE
Add include directory for DRM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,8 @@ set(SHARE_INSTALL_PREFIX
 # provide git to utilities
 find_program (GIT NAMES git)
 
+# sets DRM_INCLUDE_DIRS
+pkg_check_modules(DRM REQUIRED libdrm)
 
 ## Setup the package version based on git tags.
 set(PKG_VERSION_GIT_TAG_PREFIX "rsmi_pkg_ver")

--- a/rocm_smi/CMakeLists.txt
+++ b/rocm_smi/CMakeLists.txt
@@ -92,6 +92,11 @@ target_include_directories(${ROCM_SMI_TARGET}
                            "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
 )
 
+target_include_directories(${ROCM_SMI_TARGET}
+                          INTERFACE
+                          ${DRM_INCLUDE_DIRS}
+)
+
 ## Set the VERSION and SOVERSION values
 set_property(TARGET ${ROCM_SMI_TARGET} PROPERTY
              SOVERSION "${VERSION_MAJOR}")

--- a/rocm_smi/CMakeLists.txt
+++ b/rocm_smi/CMakeLists.txt
@@ -92,10 +92,7 @@ target_include_directories(${ROCM_SMI_TARGET}
                            "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
 )
 
-target_include_directories(${ROCM_SMI_TARGET}
-                          INTERFACE
-                          ${DRM_INCLUDE_DIRS}
-)
+target_include_directories(${ROCM_SMI_TARGET} INTERFACE ${DRM_INCLUDE_DIRS})
 
 ## Set the VERSION and SOVERSION values
 set_property(TARGET ${ROCM_SMI_TARGET} PROPERTY


### PR DESCRIPTION
This PR checks for the libdrm package and adds its include directories. This adjustment is necessary as the `kfd_ioctl.h` header file requires access to `libdrm/drm.h`.

The inclusion of libdrm directories addresses visibility issues encountered when using [Spack](https://github.com/spack/spack) for package management. In certain environments, paths to libdrm may not be automatically recognized, leading to compilation errors. 