### PR TITLE
[PATCH] Miscellaneous CMake fixes.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,15 +5,13 @@ message("&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&")
 message("                    CMake ROCm SMI (Library) [root]                ")
 message("&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&")
 cmake_minimum_required(VERSION 3.14)
+project(rocm_smi_lib)
 
 set(ROCM_SMI_LIBS_TARGET "rocm_smi_libraries")
 
 set(BUILD_SHARED_LIBS ON CACHE BOOL "Build shared library (.so) or not.")
 
-## Set default module path if not already set
-if(NOT DEFINED CMAKE_MODULE_PATH)
-    set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
-endif()
+list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules")
 ## Include common cmake modules
 include(utils)
 

--- a/oam/CMakeLists.txt
+++ b/oam/CMakeLists.txt
@@ -94,7 +94,9 @@ endif ()
 # use the target_include_directories() command to specify the include directories for the target
 target_include_directories(${OAM_TARGET}
                            PUBLIC
-                           "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+                           "$<BUILD_INTERFACE:${DRM_INCLUDE_DIRS}>"
+			   "$<BUILD_INTERFACE:${AMDGPU_DRM_INCLUDE_DIRS}>"
+			   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
                            "$<INSTALL_INTERFACE:{OAM_NAME}/include>")
 
 ## Add the install directives for the runtime library.

--- a/rocm_smi/CMakeLists.txt
+++ b/rocm_smi/CMakeLists.txt
@@ -88,7 +88,9 @@ target_include_directories(${ROCM_SMI_TARGET} PRIVATE
 # use the target_include_directories() command to specify the include directories for the target
 target_include_directories(${ROCM_SMI_TARGET}
                            PUBLIC
-                           "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+                           "$<BUILD_INTERFACE:${DRM_INCLUDE_DIRS}>"
+                           "$<BUILD_INTERFACE:${AMDGPU_DRM_INCLUDE_DIRS}>"
+			   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
                            "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
 )
 


### PR DESCRIPTION
* Adds a `project` declaration (not having this is a big anti-pattern).
* Changes the `CMAKE_MODULE_PATH` setup to be based on `list(PREPEND`. It is completely reasonable for a super-project to set `CMAKE_MODULE_PATH` and that should not influence whether the project sets up its own path. Note that PREPEND vs APPEND was chosen because the project also includes an unqualified `utils.cmake`, which is an overly broad name and is an anti-pattern. Project maintainers should properly scope their CMake file names and should change this directive to APPEND.
* Adds libdrm include directories to `librocm_smi64` and `liboam`. This is needed in situations where a non-system libdrm is being used.

Patch coming from TheRock: https://github.com/ROCm/TheRock/issues/299