### PR TITLE
Exposed the energy count and current socket power metrics to profilers like PAPI

### DIFF
--- a/src/rocm_smi_device.cc
+++ b/src/rocm_smi_device.cc
@@ -511,7 +511,11 @@ static const std::map<const char *, dev_depends_t> kDevFuncDependsMap = {
   {"rsmi_dev_xgmi_error_reset",          {{kDevXGMIErrorFName}, {}}},
   {"rsmi_dev_memory_reserved_pages_get", {{kDevMemPageBadFName}, {}}},
   {"rsmi_topo_numa_affinity_get",        {{kDevNumaNodeFName}, {}}},
+  
   {"rsmi_dev_gpu_metrics_info_get",      {{kDevGpuMetricsFName}, {}}},
+  {"rsmi_dev_energy_count_get",          {{kDevGpuMetricsFName}, {}}},
+  {"rsmi_dev_current_socket_power_get",  {{kDevGpuMetricsFName}, {}}},
+
   {"rsmi_dev_gpu_reset",                 {{kDevGpuResetFName}, {}}},
   {"rsmi_dev_compute_partition_get",     {{kDevComputePartitionFName}, {}}},
   {"rsmi_dev_compute_partition_set",     {{kDevComputePartitionFName}, {}}},


### PR DESCRIPTION
EDIT: Moved PR to https://github.com/ROCm/rocm_smi_lib/pull/225 to use the develop branch instead.

Added 2 lines that allow PAPI (https://github.com/icl-utk-edu/papi) to profile the energy and current socket power, for HPC research.

It simply adds the two functions `rsmi_dev_energy_count_get` and `rsmi_dev_current_socket_power_get` to the device function dependency map.