### PR TITLE
Exposed the energy count and current socket power metrics to profilers like PAPI

### DIFF
--- a/src/rocm_smi_device.cc
+++ b/src/rocm_smi_device.cc
@@ -510,6 +510,9 @@ static const std::map<const char *, dev_depends_t> kDevFuncDependsMap = {
   {"rsmi_topo_numa_affinity_get",        {{kDevNumaNodeFName}, {}}},
   {"rsmi_dev_gpu_metrics_info_get",      {{kDevGpuMetricsFName}, {}}},
   {"rsmi_dev_gpu_reset",                 {{kDevGpuResetFName}, {}}},
+  {"rsmi_dev_energy_count_get",          {{kDevGpuMetricsFName}, {}}},
+  {"rsmi_dev_current_socket_power_get",  {{kDevGpuMetricsFName}, {}}},
+
   {"rsmi_dev_compute_partition_get",     {{kDevComputePartitionFName}, {}}},
   {"rsmi_dev_compute_partition_set",     {{kDevComputePartitionFName}, {}}},
   {"rsmi_dev_memory_partition_get",      {{kDevMemoryPartitionFName}, {}}},


### PR DESCRIPTION
Added 2 lines that allow commonly used profilers on HPC systems (https://github.com/icl-utk-edu/papi) to gather the energy and current socket power metrics.

It simply adds the two functions `rsmi_dev_energy_count_get` and `rsmi_dev_current_socket_power_get` to the device function dependency map.

PAPI is prepared to provide energy metrics on HPC traces once this is merged:
https://github.com/icl-utk-edu/papi/pull/418#issuecomment-3021453296